### PR TITLE
Add clang format config with minimal options

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,7 @@
+# General settings
+BasedOnStyle: LLVM
+IndentWidth: 4
+
+Language: Cpp
+DerivePointerAlignment: false
+PointerAlignment: Left


### PR DESCRIPTION
This PR adds clang-format config file for enforcing uniform code style. We can tune the options in the config file according to the preferences of all group members.