### PR TITLE
Add .travis.yml and simple build script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,80 @@
+sudo: required
+language: cpp
+matrix:
+    include:
+        # GCC 6
+        - os: linux
+          addons:
+            apt:
+              sources:
+                - ubuntu-toolchain-r-test
+              packages:
+                - g++-6
+          env:
+            - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
+        # GCC 7
+        - os: linux
+          addons:
+            apt:
+              sources:
+                - ubuntu-toolchain-r-test
+              packages:
+                - g++-7
+          env:
+            - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+        # GCC 8
+        - os: linux
+          addons:
+            apt:
+              sources:
+                - ubuntu-toolchain-r-test
+              packages:
+                - g++-8
+          env:
+            - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8"
+
+        # Clang 3.6
+        - os: linux
+          addons:
+            apt:
+              sources:
+                - ubuntu-toolchain-r-test
+                - llvm-toolchain-trusty-3.6
+              packages:
+                - clang-3.6
+          env:
+            - MATRIX_EVAL="CC=clang-3.6 && CXX=clang++-3.6"
+
+        # Clang 4.0
+        - os: linux
+          addons:
+            apt:
+              sources:
+                - ubuntu-toolchain-r-test
+                - llvm-toolchain-trusty-4.0
+              packages:
+                - clang-4.0
+          env:
+            - MATRIX_EVAL="CC=clang-4.0 && CXX=clang++-4.0"
+
+        # Clang 5.0
+        - os: linux
+          addons:
+            apt:
+              sources:
+                - ubuntu-toolchain-r-test
+                - llvm-toolchain-trusty-5.0
+              packages:
+                - clang-5.0
+          env:
+            - MATRIX_EVAL="CC=clang-5.0 && CXX=clang++-5.0"
+
+before_install:
+    - eval "${MATRIX_EVAL}"
+
+script:
+    - chmod +x build.sh
+    - ./build.sh -DCMAKE_C_COMPILER="${C}" -DCMAKE_CXX_COMPILER="${CXX}"
+
+notifications:
+    email: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.9.2)
 
 # Includes
 include(CTest)
@@ -26,9 +26,6 @@ set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 add_subdirectory(${CMAKE_BINARY_DIR}/googletest-src
                  ${CMAKE_BINARY_DIR}/googletest-build
                  EXCLUDE_FROM_ALL)
-
-# CXX flags
-# set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -O3")
 
 # Project subdirectories
 add_subdirectory(src)

--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.10)
-
 project(googletest-download NONE)
 
 include(ExternalProject)

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+mkdir -p build
+cd build
+cmake "$@" ..
+make
+cd build
+ctest -V

--- a/build.sh
+++ b/build.sh
@@ -4,5 +4,4 @@ mkdir -p build
 cd build
 cmake "$@" ..
 make
-cd build
 ctest -V

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.9.2)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -std=c++11")
@@ -12,3 +12,4 @@ set(SRC_FILES
     main.cpp)
 
 add_executable(main ${SRC_FILES})
+target_link_libraries(main m)

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include<cstddef>
 
 /**
  * A simple vector type that holds the pointer to an already allocated array
@@ -6,7 +7,7 @@
  */
 struct vector_t {
     double* ptr;
-    int len;
+    size_t len;
 };
 
 /**
@@ -15,6 +16,6 @@ struct vector_t {
  */
 struct matrix_t {
     double* ptr;
-    int rows;
-    int cols;
+    size_t rows;
+    size_t cols;
 };

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,18 +1,20 @@
+cmake_minimum_required(VERSION 3.9.2)
+
 set(SOURCES
     ../src/util.cpp
     ../src/svd.cpp
     ../src/evd.cpp
     )
-set(CMAKE_CXX_FLAGS "-std=c++11")
+set(CMAKE_CXX_FLAGS "-Wall -Wextra -O3 -std=c++11")
 
 add_library(sources_lib STATIC ${SOURCES})
 
 add_executable(svd_test svd_test.cpp)
 add_executable(util_test util_test.cpp)
 add_executable(evd_test evd_test.cpp)
-target_link_libraries(svd_test gtest_main sources_lib)
-target_link_libraries(util_test gtest_main sources_lib)
-target_link_libraries(evd_test gtest_main sources_lib)
+target_link_libraries(svd_test gtest_main sources_lib m)
+target_link_libraries(util_test gtest_main sources_lib m)
+target_link_libraries(evd_test gtest_main sources_lib m)
 
 
 add_test(NAME SVD COMMAND svd_test)

--- a/test/evd_test.cpp
+++ b/test/evd_test.cpp
@@ -5,7 +5,7 @@
 #include <vector>
 
 TEST(evd, identity_matrix) {
-    int n = 10;
+    size_t n = 10;
     std::vector<double> A(n * n, 0);
     for (int i = 0; i < n; ++i) {
         A[i*n + i] = 1.0;
@@ -21,7 +21,7 @@ TEST(evd, identity_matrix) {
 }
 
 TEST(evd, random_square_matrix) {
-    int n = 4;
+    size_t n = 4;
     std::vector<double> A = {
        7.0,  3.0,  2.0,  1.0,
        3.0,  9.0,  -2.0,  4.0,

--- a/test/svd_test.cpp
+++ b/test/svd_test.cpp
@@ -6,7 +6,7 @@
 #include <random>
 
 TEST(svd, identity_matrix) {
-    int n_rows = 10, n_cols = 10;
+    size_t n_rows = 10, n_cols = 10;
     std::vector<double> X(n_rows * n_cols, 0);
     for (int i = 0; i < n_rows; ++i) {
         X[i*n_cols + i] = 1.0;
@@ -28,7 +28,7 @@ TEST(svd, identity_matrix) {
 }
 
 TEST(svd, tall_matrix) {
-    int m = 10, n = 6;
+    size_t m = 10, n = 6;
     std::vector<double> X(m*n), s(std::min(m, n)), U(m*n), V(n*n);
     for (int i = 0; i < m; ++i)
         for (int j = 0; j < n; ++j)
@@ -48,7 +48,7 @@ TEST(svd, tall_matrix) {
 }
 
 TEST(svd, random_square_matrix) {
-    int n = 3;
+    size_t n = 3;
     std::vector<double> X = {
        1.22214449,  0.20082589, -0.75672479,
        1.07593684,  0.20025264,  0.38234639,

--- a/test/util_test.cpp
+++ b/test/util_test.cpp
@@ -52,8 +52,8 @@ TEST(util, sym_jacobi_coeffs) {
 }
 
 TEST(util, reorder_decomposition) {
-    int n_cols = 10;
-    int n_rows[3] = {15, 5, 1};
+    size_t n_cols = 10;
+    size_t n_rows[3] = {15, 5, 1};
 
     // define ordered columns. Results of the shuffled inputs must be equal
     // to the original ones.


### PR DESCRIPTION
This PR adds a Travis CI config file and a simple build script to build the project and run the tests in verbose mode.

##### Notes
* Currently, we build the project on Travis CI using various versions of gcc and clang. In order to make the code compileable with clang, I had to change some type arguments in the code.
* Travis supports cmake up to version 3.9.2. So, I downgraded the cmake version to that.