### PR TITLE
Stage files after formatting in pre-commit hook

### DIFF
--- a/scripts/pre-commit.hook
+++ b/scripts/pre-commit.hook
@@ -45,5 +45,7 @@ EOF
 	exit 1
 fi
 
+staged_files=$(git diff --name-only --cached)
 scripts/format.sh
+git add ${staged_files}
 scripts/lint.sh


### PR DESCRIPTION
This PR fixes a bug of partial commits due to pre-commit hook. Previously, when pre-commit hook formatted the files, it didn't staged the new versions afterwards, causing partial and incorrect commits.