### PR TITLE
Removing Matrix Multiplication from EVD

### DIFF
--- a/src/evd/classic/evd.cpp
+++ b/src/evd/classic/evd.cpp
@@ -49,7 +49,6 @@ void evd_classic(struct matrix_t Data_matr, struct matrix_t Eigen_vectors, struc
         // Corresponding to Jacobi iteration i :
 
         for (size_t i = 0; i < m; i++) {
-
             // Compute the eigen values by updating the rows and columns
             // corresponding to the largest off-diagonal entry until convergence
 
@@ -57,7 +56,6 @@ void evd_classic(struct matrix_t Data_matr, struct matrix_t Eigen_vectors, struc
 
             A[m * i + i_max] = cos_t * A[m * i + i_max] - sin_t * A[m * i + j_max];
             A[m * i + j_max] = sin_t * A_i_imax + cos_t * A[m * i + j_max];
-
             A[m * i_max + i] = cos_t * A[m * i_max + i] - sin_t * A[m * j_max + i];
             A[m * j_max + i] = sin_t * A_imax_i + cos_t * A[m * j_max + i];
 
@@ -67,7 +65,6 @@ void evd_classic(struct matrix_t Data_matr, struct matrix_t Eigen_vectors, struc
 
             V[m * i + i_max] = cos_t * V[m * i + i_max] - sin_t * V[m * i + j_max];
             V[m * i + j_max] = sin_t * V_i_imax + cos_t * V[m * i + j_max];
-
         }
     }
 

--- a/src/evd/cyclic/evd_cyclic.cpp
+++ b/src/evd/cyclic/evd_cyclic.cpp
@@ -35,7 +35,6 @@ void evd_cyclic(struct matrix_t Data_matr, struct matrix_t Eigen_vectors, struct
 
         for (size_t row = 0; row < m; row++) {
             for (size_t col = row + 1; col < m; col++) {
-
                 // Compute cos_t and sin_t for the rotation
 
                 alpha = 2.0 * sign(A[row * m + row] - A[col * m + col]) * A[row * m + col];
@@ -60,7 +59,6 @@ void evd_cyclic(struct matrix_t Data_matr, struct matrix_t Eigen_vectors, struct
                     A[m * col + i] = cos_t * A[m * col + i] - sin_t * A_r_i;
 
                     // Compute the eigen vectors similarly by updating the eigen vector matrix
-
                     double V_i_r = V[m * i + row];
                     V[m * i + row] = cos_t * V[m * i + row] + sin_t * V[m * i + col];
                     V[m * i + col] = cos_t * V[m * i + col] - sin_t * V_i_r;

--- a/src/evd/cyclic/evd_cyclic.cpp
+++ b/src/evd/cyclic/evd_cyclic.cpp
@@ -1,6 +1,7 @@
 #include "evd_cyclic.hpp"
 #include <math.h>
 #include <stdlib.h>
+#include <stdio.h>
 #include <cassert>
 #include "matrix.hpp"
 #include "types.hpp"
@@ -18,55 +19,55 @@ void evd_cyclic(struct matrix_t Data_matr, struct matrix_t Eigen_vectors, struct
 
     int is_not_diagonal = 0;
 
-    for (size_t i = 0; i < m; i++) {
-        for (size_t j = i + 1; j < m; j++) {
-            if (A[i * m + j] != 0.0) {
-                is_not_diagonal = 1;
-                break;
-            }
-        }
-    }
+    for (int ep = 1; ep <= epoch; ep++) {
+        double alpha, beta, cos_t, sin_t;
 
-    if (is_not_diagonal) {
-        for (int ep = 1; ep <= epoch; ep++) {
-            double alpha, beta, cos_t, sin_t;
-            for (size_t row = 0; row < m; row++) {
-                for (size_t col = row + 1; col < m; col++) {
-
-                    // Compute cos_t and sin_t for the rotation
-
-                    alpha = 2.0 * sign(A[row * m + row] - A[col * m + col]) * A[row * m + col];
-                    beta = fabs(A[row * m + row] - A[col * m + col]);
-                    cos_t = sqrt(0.5 * (1 + beta / sqrt(alpha * alpha + beta * beta)));
-                    // sin_t = (1 / 2*cos_t) * (alpha / sqrt(alpha*alpha + beta*beta));
-                    sin_t = sign(alpha) * sqrt(1 - cos_t * cos_t);
-
-                    // Corresponding to Jacobi iteration i :
-
-                    for (size_t i = 0; i < m; i++) {
-
-                        // Compute the eigen values by updating the rows and columns
-                        // corresponding to the largest off-diagonal entry until convergence
-
-                        double A_i_imax = A[m * i + i_max], A_imax_i = A[m * i_max + i];
-
-                        A[m * i + i_max] = cos_t * A[m * i + i_max] - sin_t * A[m * i + j_max];
-                        A[m * i + j_max] = sin_t * A_i_imax + cos_t * A[m * i + j_max];
-
-                        A[m * i_max + i] = cos_t * A[m * i_max + i] - sin_t * A[m * j_max + i];
-                        A[m * j_max + i] = sin_t * A_imax_i + cos_t * A[m * j_max + i];
-
-                        // Compute the eigen vectors similarly by updating the eigen vector matrix
-
-                        double V_i_imax = V[m * i + i_max];
-
-                        V[m * i + i_max] = cos_t * V[m * i + i_max] - sin_t * V[m * i + j_max];
-                        V[m * i + j_max] = sin_t * V_i_imax + cos_t * V[m * i + j_max];
-
-                    }
+        for (size_t i = 0; i < m; i++) {
+            for (size_t j = i + 1; j < m; j++) {
+                if (A[i * m + j] != 0.0) {
+                    is_not_diagonal = 1;
+                    break;
                 }
             }
         }
+
+        if (!is_not_diagonal) break;
+
+        for (size_t row = 0; row < m; row++) {
+            for (size_t col = row + 1; col < m; col++) {
+
+                // Compute cos_t and sin_t for the rotation
+
+                alpha = 2.0 * sign(A[row * m + row] - A[col * m + col]) * A[row * m + col];
+                beta = fabs(A[row * m + row] - A[col * m + col]);
+                cos_t = sqrt(0.5 * (1 + beta / sqrt(alpha * alpha + beta * beta)));
+                // sin_t = (1 / 2*cos_t) * (alpha / sqrt(alpha*alpha + beta*beta));
+                sin_t = sign(alpha) * sqrt(1 - cos_t * cos_t);
+
+                for (size_t i = 0; i < m; i++) {
+                    // Compute the eigen values by updating the rows until convergence
+
+                    double A_i_r = A[m * i + row];
+                    A[m * i + row] = cos_t * A[m * i + row] + sin_t * A[m * i + col];
+                    A[m * i + col] = cos_t * A[m * i + col] - sin_t * A_i_r;
+                }
+
+                for (size_t i = 0; i < m; i++) {
+                    // Compute the eigen values by updating the columns until convergence
+
+                    double A_r_i = A[m * row + i];
+                    A[m * row + i] = cos_t * A[m * row + i] + sin_t * A[m * col + i];
+                    A[m * col + i] = cos_t * A[m * col + i] - sin_t * A_r_i;
+
+                    // Compute the eigen vectors similarly by updating the eigen vector matrix
+
+                    double V_i_r = V[m * i + row];
+                    V[m * i + row] = cos_t * V[m * i + row] + sin_t * V[m * i + col];
+                    V[m * i + col] = cos_t * V[m * i + col] - sin_t * V_i_r;
+                }
+            }
+        }
+        is_not_diagonal = 0;
     }
 
     // Store the generated eigen values in the vector


### PR DESCRIPTION
This PR removes MM from Classic and Cyclic EVD without tolerance. It also adds a diagonal matrix check to reduce the number of epochs in case the matrix has already converged.