### PR TITLE
Enable running single benchmark with script

### DIFF
--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -1,13 +1,32 @@
 #!/usr/bin/env sh
+#
+# Usage: Run from the project root directory. Use without any arguments to run all benchmarks. If you give the path to
+#        one of the benchmark executables, all the benchmarks for that specific executable will be run only.
 
-for bin in bin/benchmark/svd/*; do
-    for input in `ls -v perf/resources/svd/* | head -4`; do
+run_all () {
+    bin=$1
+    dir=""
+    if [[ $bin == *"svd"* ]];
+    then
+        dir=perf/resources/svd
+    else
+        dir=perf/resources/evd
+    fi
+    for input in `ls -v ${dir}/* | head -4`; do
         [ -f "$bin" ] && [ -x "$bin" ] && "$bin" < "$input"
     done
-done
+}
 
-for bin in bin/benchmark/evd/*; do
-    for input in `ls -v perf/resources/evd/* | head -4`; do
-        [ -f "$bin" ] && [ -x "$bin" ] && "$bin" < "$input"
+param=$1
+if [ $# -eq 0 ];
+then
+    for bin in bin/benchmark/svd/*; do
+        run_all $bin
     done
-done
+
+    for bin in bin/benchmark/evd/*; do
+        run_all $bin
+    done
+else
+    run_all $param
+fi


### PR DESCRIPTION
This PR enable running only one benchmark executable with all input files. This prevents running all benchmark executables when we want to focus on only one of them.