### PR TITLE
Fix bug in blocked svd and evd

### DIFF
--- a/src/evd/cyclic/evd_cyclic_blocked.cpp
+++ b/src/evd/cyclic/evd_cyclic_blocked.cpp
@@ -28,7 +28,7 @@ size_t evd_cyclic_blocked(struct matrix_t Data_matr, struct matrix_t Data_matr_c
 
     matrix_identity(Eigen_vectors);
 
-    if (n < 2 * block_size) {
+    if (n <= 2 * block_size) {
         block_cost = evd_block(Amat, Eigen_vectors, block_epoch);
 
         // Store the generated eigen values in the vector
@@ -127,7 +127,7 @@ size_t evd_cyclic_blocked_less_copy(struct matrix_t Data_matr, struct matrix_t D
 
     matrix_identity(Eigen_vectors);
 
-    if (n < 2 * block_size) {
+    if (n <= 2 * block_size) {
         evd_block(Amat, Eigen_vectors, block_epoch);
 
         // Store the generated eigen values in the vector

--- a/src/evd/cyclic/evd_cyclic_blocked_unroll_outer.cpp
+++ b/src/evd/cyclic/evd_cyclic_blocked_unroll_outer.cpp
@@ -28,7 +28,7 @@ size_t evd_cyclic_blocked_unroll_outer(struct matrix_t Data_matr, struct matrix_
 
     matrix_identity(Eigen_vectors);
 
-    if (n < 2 * block_size) {
+    if (n <= 2 * block_size) {
         evd_block(Amat, Eigen_vectors, block_epoch);
 
         // Store the generated eigen values in the vector
@@ -128,7 +128,7 @@ size_t evd_cyclic_blocked_unroll_outer_less_copy(struct matrix_t Data_matr, stru
 
     matrix_identity(Eigen_vectors);
 
-    if (n < 2 * block_size) {
+    if (n <= 2 * block_size) {
         evd_block(Amat, Eigen_vectors, block_epoch);
 
         // Store the generated eigen values in the vector

--- a/src/evd/cyclic/evd_cyclic_blocked_vectorize.cpp
+++ b/src/evd/cyclic/evd_cyclic_blocked_vectorize.cpp
@@ -28,7 +28,7 @@ size_t evd_cyclic_blocked_vectorize(struct matrix_t Data_matr, struct matrix_t D
     size_t sub_cost = 0;
     matrix_identity(Eigen_vectors);
 
-    if (n < 2 * block_size) {
+    if (n <= 2 * block_size) {
         evd_block_vector(Amat, Eigen_vectors, block_epoch);
 
         // Store the generated eigen values in the vector
@@ -126,7 +126,7 @@ size_t evd_cyclic_blocked_less_copy_vectorize(struct matrix_t Data_matr, struct 
 
     matrix_identity(Eigen_vectors);
 
-    if (n < 2 * block_size) {
+    if (n <= 2 * block_size) {
         evd_block_vector(Amat, Eigen_vectors, block_epoch);
 
         // Store the generated eigen values in the vector

--- a/src/svd/two-sided/svd_blocked.cpp
+++ b/src/svd/two-sided/svd_blocked.cpp
@@ -33,7 +33,7 @@ size_t svd_blocked(struct matrix_t Amat, struct matrix_t Bmat, struct matrix_t U
 
     const size_t n_blocks = n / block_size;
 
-    if (n < 2 * block_size) {
+    if (n <= 2 * block_size) {
         size_t block_iters = svd_subprocedure_vectorized(Bmat, Umat, Vmat);
         return base_cost(n, block_iters);
     }

--- a/src/svd/two-sided/svd_blocked_less_copy.cpp
+++ b/src/svd/two-sided/svd_blocked_less_copy.cpp
@@ -33,8 +33,8 @@ size_t svd_blocked_less_copy(struct matrix_t Amat, struct matrix_t Bmat, struct 
 
     const size_t n_blocks = n / block_size;
 
-    if (n < 2 * block_size) {
-        size_t block_iters = svd_subprocedure(Bmat, Umat, Vmat);
+    if (n <= 2 * block_size) {
+        size_t block_iters = svd_subprocedure_vectorized_with_transpose(Bmat, Umat, Vmat);
         return base_cost(n, block_iters);
     }
 

--- a/src/svd/two-sided/svd_blocked_less_copy_transposed.cpp
+++ b/src/svd/two-sided/svd_blocked_less_copy_transposed.cpp
@@ -33,7 +33,7 @@ size_t svd_blocked_less_copy_transposed(struct matrix_t Amat, struct matrix_t Bm
 
     const size_t n_blocks = n / block_size;
 
-    if (n < 2 * block_size) {
+    if (n <= 2 * block_size) {
         size_t block_iters = svd_subprocedure_vectorized_rowwise(Bmat, Vmat, Umat);
         matrix_transpose(Umat, Umat);
         matrix_transpose(Vmat, Vmat);


### PR DESCRIPTION
The blocked implementations operate on matrices of size 2 * block size by 2 * block size. If the matrix size is 2 * block size by 2 * block size or smaller then there is no point in applying blocking. Previously
we considered only the case where the matrix is smaller than 2 * block size by 2 * block size and not equal, which leads to unnecessary computations that do not add anything to the final result.